### PR TITLE
Improved errorhandling

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ plugins {
   // your other plugins...
    id 'signing'
    id 'maven-publish'
-   id("se.alipsa.nexus-release-plugin") version '2.0.0'
+   id("se.alipsa.nexus-release-plugin") version '2.1.0'
 }
 
 publishing {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = 'se.alipsa'
-version = '2.1.0-SNAPSHOT'
+version = '2.1.0'
 description = 'Automates the release process in Central Portal after signing has completed'
 
 gradlePlugin {

--- a/release.md
+++ b/release.md
@@ -1,5 +1,15 @@
 # Release history
 
+## Ver 2.1.0, 2026-02-27
+- Added upfront bundle validation before upload:
+  - credentials must be configured
+  - required `.jar`/`.pom` and `.asc` entries must exist in the bundle
+  - artifact filename consistency is validated against `artifactId` and `version`
+  - POM metadata required by Maven Central is validated
+- Improved Central Portal failure reporting by parsing full deployment status and logging validation errors when deployment state is `FAILED`.
+- Improved HTTP handling in API client calls by checking non-2xx responses and surfacing status/body in explicit exceptions.
+- Added tests for bundle validation rules, upload error handling (401/403/422), and pre-upload release failures.
+
 ## Ver 2.0.1, 2026-01-30
 - Updated the plugin to use the provider APIs to be fully configuration cache compatible.
 

--- a/src/main/groovy/se/alipsa/gradle/plugin/release/BundleValidator.groovy
+++ b/src/main/groovy/se/alipsa/gradle/plugin/release/BundleValidator.groovy
@@ -1,0 +1,149 @@
+package se.alipsa.gradle.plugin.release
+
+import groovy.xml.XmlSlurper
+import groovy.xml.slurpersupport.GPathResult
+
+import java.util.zip.ZipEntry
+import java.util.zip.ZipFile
+
+class BundleValidator {
+
+    static List<String> validateBundle(
+        File zipFile,
+        String groupId,
+        String artifactId,
+        String version,
+        String userName,
+        String password
+    ) {
+        List<String> errors = []
+        validateCredentials(userName, password, errors)
+        validateZip(zipFile, groupId, artifactId, version, errors)
+        return errors
+    }
+
+    private static void validateCredentials(String userName, String password, List<String> errors) {
+        if (isBlank(userName) || isBlank(password)) {
+            errors.add(
+                """Credentials not configured. Add the following to ~/.gradle/gradle.properties:
+  sonatypeUsername=<your user token>
+  sonatypePassword=<your password token>""".stripIndent()
+            )
+        }
+    }
+
+    private static void validateZip(File zipFile, String groupId, String artifactId, String version, List<String> errors) {
+        if (!zipFile.exists()) {
+            errors.add("Expected bundle at ${zipFile.absolutePath} but it was not found.")
+            return
+        }
+
+        String basePath = "${groupId.replace('.', '/')}/${artifactId}/${version}/"
+        String artifactPrefix = "${artifactId}-${version}"
+        List<String> requiredEntries = [
+            "${basePath}${artifactPrefix}.pom",
+            "${basePath}${artifactPrefix}.pom.asc",
+            "${basePath}${artifactPrefix}.jar",
+            "${basePath}${artifactPrefix}.jar.asc",
+            "${basePath}${artifactPrefix}-sources.jar",
+            "${basePath}${artifactPrefix}-sources.jar.asc",
+            "${basePath}${artifactPrefix}-javadoc.jar",
+            "${basePath}${artifactPrefix}-javadoc.jar.asc"
+        ]
+
+        try (ZipFile zip = new ZipFile(zipFile)) {
+            Set<String> names = zip.entries().collect { ZipEntry e -> e.name } as Set<String>
+            requiredEntries.each { String requiredEntry ->
+                if (!names.contains(requiredEntry)) {
+                    errors.add("Missing required bundle entry: ${requiredEntry}")
+                }
+            }
+
+            validateFileNameConsistency(names, artifactPrefix, artifactId, errors)
+            validatePom(zip, "${basePath}${artifactPrefix}.pom", errors)
+        } catch (IOException e) {
+            errors.add("Failed to inspect bundle ${zipFile.absolutePath}: ${e.message}")
+        }
+    }
+
+    private static void validateFileNameConsistency(Set<String> names, String artifactPrefix, String artifactId, List<String> errors) {
+        names.each { String name ->
+            if (!name.endsWith('.jar') && !name.endsWith('.pom')) {
+                return
+            }
+            String fileName = name.tokenize('/').last()
+            if (!fileName.startsWith(artifactPrefix)) {
+                errors.add(
+                    """Filename mismatch: '${fileName}' does not start with '${artifactPrefix}'
+  -> Make sure base.archivesName = '${artifactId}' matches artifactId = '${artifactId}'""".stripIndent()
+                )
+            }
+        }
+    }
+
+    private static void validatePom(ZipFile zip, String expectedPomPath, List<String> errors) {
+        ZipEntry pomEntry = zip.getEntry(expectedPomPath)
+        if (pomEntry == null) {
+            errors.add("POM not found in bundle at ${expectedPomPath}")
+            return
+        }
+
+        String pomText = zip.getInputStream(pomEntry).getText('UTF-8')
+        GPathResult pom
+        try {
+            pom = new XmlSlurper(false, false).parseText(pomText)
+        } catch (Exception e) {
+            errors.add("Failed to parse POM ${expectedPomPath}: ${e.message}")
+            return
+        }
+
+        checkTextField(pom, 'name', '<name>', errors)
+        checkTextField(pom, 'description', '<description>', errors)
+        checkTextField(pom, 'url', '<url>', errors)
+
+        def licenses = pom.licenses.license
+        if (licenses.size() == 0) {
+            errors.add("POM is missing required field: <licenses>")
+        } else {
+            boolean validLicenseFound = false
+            licenses.each { license ->
+                if (!isBlank(license.name?.text()) && !isBlank(license.url?.text())) {
+                    validLicenseFound = true
+                }
+            }
+            if (!validLicenseFound) {
+                errors.add("POM <licenses> must contain at least one <license> with <name> and <url>")
+            }
+        }
+
+        def developers = pom.developers.developer
+        if (developers.size() == 0) {
+            errors.add("POM is missing required field: <developers>")
+        } else {
+            boolean validDeveloperFound = false
+            developers.each { developer ->
+                if (!isBlank(developer.id?.text()) || !isBlank(developer.name?.text())) {
+                    validDeveloperFound = true
+                }
+            }
+            if (!validDeveloperFound) {
+                errors.add("POM <developers> must contain at least one <developer> with <id> or <name>")
+            }
+        }
+
+        if (isBlank(pom.scm.url?.text()) || isBlank(pom.scm.connection?.text())) {
+            errors.add("POM <scm> must contain both <url> and <connection>")
+        }
+    }
+
+    private static void checkTextField(GPathResult pom, String fieldName, String fieldLabel, List<String> errors) {
+        String value = pom."${fieldName}"?.text()
+        if (isBlank(value)) {
+            errors.add("POM is missing required field: ${fieldLabel}")
+        }
+    }
+
+    private static boolean isBlank(String value) {
+        value == null || value.trim().isEmpty()
+    }
+}

--- a/src/main/groovy/se/alipsa/gradle/plugin/release/NexusReleasePlugin.groovy
+++ b/src/main/groovy/se/alipsa/gradle/plugin/release/NexusReleasePlugin.groovy
@@ -53,6 +53,8 @@ class NexusReleasePlugin implements Plugin<Project> {
             // Wire project metadata
             task.projectVersion.set(project.provider { project.version.toString() })
             task.projectName.set(project.provider { project.name })
+            task.groupId.set(extension.mavenPublication.map { it.groupId })
+            task.artifactId.set(extension.mavenPublication.map { it.artifactId })
 
             // Wire credentials from extension
             task.nexusUrl.set(extension.nexusUrl)

--- a/src/main/groovy/se/alipsa/gradle/plugin/release/WsException.groovy
+++ b/src/main/groovy/se/alipsa/gradle/plugin/release/WsException.groovy
@@ -1,0 +1,21 @@
+package se.alipsa.gradle.plugin.release
+
+import groovy.transform.CompileStatic
+
+@CompileStatic
+class WsException extends IOException {
+    final int statusCode
+    final String body
+
+    WsException(int statusCode, String body) {
+        super("HTTP ${statusCode}: ${body ?: ''}".toString())
+        this.statusCode = statusCode
+        this.body = body
+    }
+
+    WsException(int statusCode, String body, Throwable cause) {
+        super("HTTP ${statusCode}: ${body ?: ''}".toString(), cause)
+        this.statusCode = statusCode
+        this.body = body
+    }
+}

--- a/src/test/groovy/se/alipsa/gradle/plugin/release/BundleValidatorTest.groovy
+++ b/src/test/groovy/se/alipsa/gradle/plugin/release/BundleValidatorTest.groovy
@@ -1,0 +1,156 @@
+package se.alipsa.gradle.plugin.release
+
+import org.junit.jupiter.api.Test
+
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+import static org.junit.jupiter.api.Assertions.assertTrue
+import static org.junit.jupiter.api.Assertions.assertEquals
+
+class BundleValidatorTest {
+
+  @Test
+  void validBundleHasNoErrors() {
+    File zipFile = createBundleZip('com.example', 'demo', '1.0.0', validPom(), [
+        'demo-1.0.0.jar',
+        'demo-1.0.0.jar.asc',
+        'demo-1.0.0-sources.jar',
+        'demo-1.0.0-sources.jar.asc',
+        'demo-1.0.0-javadoc.jar',
+        'demo-1.0.0-javadoc.jar.asc',
+        'demo-1.0.0.pom.asc'
+    ])
+
+    List<String> errors = BundleValidator.validateBundle(zipFile, 'com.example', 'demo', '1.0.0', 'user', 'pass')
+
+    assertTrue(errors.isEmpty(), "Expected no validation errors but got: ${errors}")
+  }
+
+  @Test
+  void missingCredentialsIsReported() {
+    File zipFile = createBundleZip('com.example', 'demo', '1.0.0', validPom(), [
+        'demo-1.0.0.jar',
+        'demo-1.0.0.jar.asc',
+        'demo-1.0.0-sources.jar',
+        'demo-1.0.0-sources.jar.asc',
+        'demo-1.0.0-javadoc.jar',
+        'demo-1.0.0-javadoc.jar.asc',
+        'demo-1.0.0.pom.asc'
+    ])
+
+    List<String> errors = BundleValidator.validateBundle(zipFile, 'com.example', 'demo', '1.0.0', '', '')
+
+    assertTrue(errors.any { it.contains('Credentials not configured') })
+  }
+
+  @Test
+  void missingRequiredEntriesAreReported() {
+    File zipFile = createBundleZip('com.example', 'demo', '1.0.0', validPom(), [
+        'demo-1.0.0.jar',
+        'demo-1.0.0.pom.asc'
+    ])
+
+    List<String> errors = BundleValidator.validateBundle(zipFile, 'com.example', 'demo', '1.0.0', 'user', 'pass')
+
+    assertTrue(errors.any { it.contains('Missing required bundle entry') && it.contains('demo-1.0.0-sources.jar') })
+    assertTrue(errors.any { it.contains('Missing required bundle entry') && it.contains('demo-1.0.0-javadoc.jar') })
+  }
+
+  @Test
+  void filenameMismatchIsReported() {
+    File zipFile = createBundleZip('com.example', 'demo', '1.0.0', validPom(), [
+        'wrong-1.0.0.jar',
+        'wrong-1.0.0.jar.asc',
+        'wrong-1.0.0-sources.jar',
+        'wrong-1.0.0-sources.jar.asc',
+        'wrong-1.0.0-javadoc.jar',
+        'wrong-1.0.0-javadoc.jar.asc',
+        'demo-1.0.0.pom.asc'
+    ])
+
+    List<String> errors = BundleValidator.validateBundle(zipFile, 'com.example', 'demo', '1.0.0', 'user', 'pass')
+
+    assertTrue(errors.any { it.contains("Filename mismatch: 'wrong-1.0.0.jar'") })
+  }
+
+  @Test
+  void pomValidationErrorsAccumulate() {
+    String invalidPom = '''
+      <project>
+        <modelVersion>4.0.0</modelVersion>
+        <groupId>com.example</groupId>
+        <artifactId>demo</artifactId>
+        <version>1.0.0</version>
+      </project>
+    '''.stripIndent()
+
+    File zipFile = createBundleZip('com.example', 'demo', '1.0.0', invalidPom, [
+        'demo-1.0.0.jar',
+        'demo-1.0.0.jar.asc',
+        'demo-1.0.0-sources.jar',
+        'demo-1.0.0-sources.jar.asc',
+        'demo-1.0.0-javadoc.jar',
+        'demo-1.0.0-javadoc.jar.asc',
+        'demo-1.0.0.pom.asc'
+    ])
+
+    List<String> errors = BundleValidator.validateBundle(zipFile, 'com.example', 'demo', '1.0.0', 'user', 'pass')
+
+    assertTrue(errors.any { it.contains('POM is missing required field: <name>') })
+    assertTrue(errors.any { it.contains('POM is missing required field: <description>') })
+    assertTrue(errors.any { it.contains('POM is missing required field: <licenses>') })
+    assertTrue(errors.any { it.contains('POM is missing required field: <developers>') })
+    assertTrue(errors.any { it.contains('POM <scm> must contain both <url> and <connection>') })
+    assertTrue(errors.size() >= 5)
+  }
+
+  private static File createBundleZip(String groupId, String artifactId, String version, String pomText, List<String> fileNames) {
+    File dir = File.createTempDir('bundle-validator-test', '')
+    File zipFile = new File(dir, 'bundle.zip')
+    String basePath = "${groupId.replace('.', '/')}/${artifactId}/${version}/"
+
+    try (ZipOutputStream zipOut = new ZipOutputStream(new FileOutputStream(zipFile))) {
+      zipOut.putNextEntry(new ZipEntry("${basePath}${artifactId}-${version}.pom"))
+      zipOut.write(pomText.getBytes('UTF-8'))
+      zipOut.closeEntry()
+
+      fileNames.each { String fileName ->
+        zipOut.putNextEntry(new ZipEntry(basePath + fileName))
+        zipOut.write('x'.bytes)
+        zipOut.closeEntry()
+      }
+    }
+    return zipFile
+  }
+
+  private static String validPom() {
+    return '''
+      <project>
+        <modelVersion>4.0.0</modelVersion>
+        <groupId>com.example</groupId>
+        <artifactId>demo</artifactId>
+        <version>1.0.0</version>
+        <name>Demo</name>
+        <description>Demo artifact</description>
+        <url>https://example.com/demo</url>
+        <licenses>
+          <license>
+            <name>MIT</name>
+            <url>https://opensource.org/licenses/MIT</url>
+          </license>
+        </licenses>
+        <developers>
+          <developer>
+            <id>demo</id>
+            <name>Demo User</name>
+          </developer>
+        </developers>
+        <scm>
+          <url>https://example.com/demo</url>
+          <connection>scm:git:https://example.com/demo.git</connection>
+        </scm>
+      </project>
+    '''.stripIndent()
+  }
+}

--- a/src/test/groovy/se/alipsa/gradle/plugin/release/CentralUploadApiTest.groovy
+++ b/src/test/groovy/se/alipsa/gradle/plugin/release/CentralUploadApiTest.groovy
@@ -4,13 +4,20 @@ import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
+import org.gradle.api.GradleException
+import org.gradle.testfixtures.ProjectBuilder
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
-import org.junit.jupiter.api.*
-import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
 
 import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertThrows
 import static org.junit.jupiter.api.Assertions.assertTrue
 
 class CentralUploadApiTest {
@@ -29,21 +36,23 @@ class CentralUploadApiTest {
 
   @Test
   void testCentralPortalClientUpload() {
-    // Mock server response
-    server.enqueue(new MockResponse()
-        .setResponseCode(200)
-        .setBody('1234567')
-    )
+    server.setDispatcher(new Dispatcher() {
+      @Override
+      MockResponse dispatch(RecordedRequest request) {
+        if (request.path.startsWith('/api/v1/publisher/upload')) {
+          return new MockResponse().setResponseCode(200).setBody('1234567')
+        }
+        return new MockResponse().setResponseCode(404).setBody('Not Found')
+      }
+    })
 
     String urlPath = "/api/v1/publisher/upload?publishingType=AUTOMATIC"
     def url = server.url(urlPath)
     def targetUrl = "${url.scheme()}://${url.host()}:${url.port()}/api/v1".toString()
-    //return
-    // Prepare zip file
+
     String buildScript = TestFixtures.createBuildScript(targetUrl)
     File testProjectDir = TestFixtures.createTestProject(buildScript)
 
-    // Run build
     BuildResult result = GradleRunner.create()
         .withProjectDir(testProjectDir)
         .withArguments("bundle")
@@ -51,88 +60,176 @@ class CentralUploadApiTest {
         .forwardOutput()
         .build()
 
-    assertEquals(TaskOutcome.SUCCESS, result.task(":bundle").getOutcome())
+    assertEquals(TaskOutcome.SUCCESS, result.task(":bundle").outcome)
 
-    File zipFile = new File(testProjectDir,"build/zips/test-project-1.0.0-bundle.zip")
+    File zipFile = new File(testProjectDir, "build/zips/test-project-1.0.0-bundle.zip")
     assertTrue(zipFile.exists(), "ZIP file should be created")
 
     def project = ProjectBuilder.builder()
         .withProjectDir(testProjectDir)
         .build()
-    println "TargetUrl = $targetUrl"
     CentralPortalClient portalClient = new CentralPortalClient(project.logger, targetUrl, null, null)
     portalClient.upload(zipFile)
 
-    // Inspect request to the mock server
     def recorded = server.takeRequest()
     assert recorded.method == "POST"
     assert recorded.path.contains("publishingType=AUTOMATIC")
     assert recorded.getHeader("Authorization")?.startsWith("Bearer ")
-    def actualPath = recorded.requestUrl.encodedPath()  + "?" + recorded.requestUrl.query()
+    def actualPath = recorded.requestUrl.encodedPath() + "?" + recorded.requestUrl.query()
     assertEquals(urlPath, actualPath)
   }
 
   @Test
-  void 'should upload bundle successfully'() {
-    // Mock server response
+  void shouldUploadAndPollSuccessfully() {
     String deploymentId = '1234567'
-    // Mock server response
     server.setDispatcher(new Dispatcher() {
       @Override
       MockResponse dispatch(RecordedRequest request) {
-        if (request.path.startsWith("/api/v1/publisher/upload")) {
-          return new MockResponse()
-              .setResponseCode(200)
-              .setBody(deploymentId)
-        } else if (request.path.startsWith("/api/v1/publisher/status")) {
-          def query = request.requestUrl?.queryParameter("id")
-          if (query == deploymentId) {
-            return new MockResponse()
-                .setResponseCode(200)
-                .setBody("""{  
-                "deploymentId": "${deploymentId}",
-                "deploymentName": "central-bundle.zip",
-                "deploymentState": "PUBLISHING"
-                }""".stripIndent())
-          } else {
-            return new MockResponse()
-                .setResponseCode(404)
-                .setBody("Not Found")
-          }
+        if (request.path.startsWith('/api/v1/publisher/upload')) {
+          return new MockResponse().setResponseCode(200).setBody(deploymentId)
         }
-        return new MockResponse()
-            .setResponseCode(404)
-            .setBody("Unknown path: ${request.path}")
+        if (request.path.startsWith('/api/v1/publisher/status')) {
+          def query = request.requestUrl?.queryParameter('id')
+          if (query == deploymentId) {
+            return new MockResponse().setResponseCode(200).setBody("""{
+              "deploymentId": "${deploymentId}",
+              "deploymentName": "central-bundle.zip",
+              "deploymentState": "PUBLISHING"
+            }""".stripIndent())
+          }
+          return new MockResponse().setResponseCode(404).setBody('Not Found')
+        }
+        return new MockResponse().setResponseCode(404).setBody("Unknown path: ${request.path}")
       }
     })
+
     String urlPath = "/api/v1/publisher/upload?publishingType=AUTOMATIC"
     def url = server.url(urlPath)
     def targetUrl = "${url.scheme()}://${url.host()}:${url.port()}/api/v1".toString()
 
-    // Prepare zip file
     String buildScript = TestFixtures.createBuildScript(targetUrl)
     File testProjectDir = TestFixtures.createTestProject(buildScript)
 
-    // Run build
     BuildResult result = GradleRunner.create()
         .withProjectDir(testProjectDir)
-        .withArguments("release")
+        .withArguments('release')
         .withPluginClasspath()
         .forwardOutput()
         .build()
 
-    assertEquals(TaskOutcome.SUCCESS, result.task(":release").getOutcome())
+    assertEquals(TaskOutcome.SUCCESS, result.task(':release').outcome)
 
-    File zipFile = new File(testProjectDir,"build/zips/test-project-1.0.0-bundle.zip")
-    assertTrue(zipFile.exists(), "ZIP file should be created")
+    File zipFile = new File(testProjectDir, 'build/zips/test-project-1.0.0-bundle.zip')
+    assertTrue(zipFile.exists(), 'ZIP file should be created')
 
-
-    // Inspect request to the mock server
     def recorded = server.takeRequest()
-    assert recorded.method == "POST"
-    assert recorded.path.contains("publishingType=AUTOMATIC")
-    assert recorded.getHeader("Authorization")?.startsWith("Bearer ")
-    def actualPath = recorded.requestUrl.encodedPath()  + "?" + recorded.requestUrl.query()
+    assert recorded.method == 'POST'
+    assert recorded.path.contains('publishingType=AUTOMATIC')
+    assert recorded.getHeader('Authorization')?.startsWith('Bearer ')
+    def actualPath = recorded.requestUrl.encodedPath() + '?' + recorded.requestUrl.query()
     assertEquals(urlPath, actualPath)
+  }
+
+  @Test
+  void upload401ReturnsFriendlyMessage() {
+    withUploadStatus(401, '{"error":"bad credentials"}') { String targetUrl ->
+      CentralPortalClient client = new CentralPortalClient(ProjectBuilder.builder().build().logger, targetUrl, 'u', 'p')
+      GradleException ex = assertThrows(GradleException) {
+        client.upload(createDummyZip())
+      }
+      assertTrue(ex.message.contains('Authentication failed - check sonatypeUsername/sonatypePassword'))
+    }
+  }
+
+  @Test
+  void upload403ReturnsFriendlyMessage() {
+    withUploadStatus(403, '{"error":"namespace not verified"}') { String targetUrl ->
+      CentralPortalClient client = new CentralPortalClient(ProjectBuilder.builder().build().logger, targetUrl, 'u', 'p')
+      GradleException ex = assertThrows(GradleException) {
+        client.upload(createDummyZip())
+      }
+      assertTrue(ex.message.contains('Forbidden - is the namespace verified in your Central Portal account?'))
+    }
+  }
+
+  @Test
+  void upload422ReturnsBodyInMessage() {
+    withUploadStatus(422, '{"error":"malformed bundle"}') { String targetUrl ->
+      CentralPortalClient client = new CentralPortalClient(ProjectBuilder.builder().build().logger, targetUrl, 'u', 'p')
+      GradleException ex = assertThrows(GradleException) {
+        client.upload(createDummyZip())
+      }
+      assertTrue(ex.message.contains('Rejected by Central Portal - see body for details'))
+      assertTrue(ex.message.contains('malformed bundle'))
+    }
+  }
+
+  @Test
+  void failedStatusErrorsAreLogged() {
+    String deploymentId = '1234567'
+    server.setDispatcher(new Dispatcher() {
+      @Override
+      MockResponse dispatch(RecordedRequest request) {
+        if (request.path.startsWith('/api/v1/publisher/upload')) {
+          return new MockResponse().setResponseCode(200).setBody(deploymentId)
+        }
+        if (request.path.startsWith('/api/v1/publisher/status')) {
+          return new MockResponse().setResponseCode(200).setBody('''
+            {
+              "deploymentId": "1234567",
+              "deploymentState": "FAILED",
+              "errors": [
+                {"component": "sieparser-2.0.jar", "message": "Artifact coordinates mismatch"}
+              ]
+            }
+          '''.stripIndent())
+        }
+        return new MockResponse().setResponseCode(404).setBody('Not Found')
+      }
+    })
+
+    String urlPath = '/api/v1/publisher/upload?publishingType=AUTOMATIC'
+    def url = server.url(urlPath)
+    String targetUrl = "${url.scheme()}://${url.host()}:${url.port()}/api/v1"
+
+    String buildScript = TestFixtures.createBuildScript(targetUrl)
+    File testProjectDir = TestFixtures.createTestProject(buildScript)
+
+    BuildResult result = GradleRunner.create()
+        .withProjectDir(testProjectDir)
+        .withArguments('release')
+        .withPluginClasspath()
+        .forwardOutput()
+        .buildAndFail()
+
+    assertTrue(result.output.contains('Deployment FAILED. Validation errors reported by Maven Central:'))
+    assertTrue(result.output.contains('sieparser-2.0.jar: Artifact coordinates mismatch'))
+    assertTrue(result.output.contains('Failed to release test-project with deploymentId 1234567'))
+  }
+
+  private static void withUploadStatus(int code, String body, Closure<?> assertion) {
+    server.setDispatcher(new Dispatcher() {
+      @Override
+      MockResponse dispatch(RecordedRequest request) {
+        if (request.path.startsWith('/api/v1/publisher/upload')) {
+          return new MockResponse().setResponseCode(code).setBody(body)
+        }
+        return new MockResponse().setResponseCode(404).setBody('Not Found')
+      }
+    })
+    def url = server.url('/api/v1/publisher/upload?publishingType=AUTOMATIC')
+    String targetUrl = "${url.scheme()}://${url.host()}:${url.port()}/api/v1"
+    assertion.call(targetUrl)
+  }
+
+  private static File createDummyZip() {
+    File dir = File.createTempDir('central-upload', '')
+    File zipFile = new File(dir, 'bundle.zip')
+    try (ZipOutputStream zipOut = new ZipOutputStream(new FileOutputStream(zipFile))) {
+      zipOut.putNextEntry(new ZipEntry('dummy.txt'))
+      zipOut.write('x'.bytes)
+      zipOut.closeEntry()
+    }
+    return zipFile
   }
 }

--- a/src/test/groovy/se/alipsa/gradle/plugin/release/TestFixtures.groovy
+++ b/src/test/groovy/se/alipsa/gradle/plugin/release/TestFixtures.groovy
@@ -22,7 +22,7 @@ import java.security.Security
 class TestFixtures {
 
   static String createBuildScript(String nexusReleaseUrl, String identity = "test@example.com", char[] passphrase = []) {
-    buildScript(generateTestPrivateKey(identity, passphrase), nexusReleaseUrl, identity, new String(passphrase))
+    buildScript(generateTestPrivateKey(identity, passphrase), nexusReleaseUrl, "sonaTypeUserName", "sonaTypePassword")
   }
 
   static String createBuildScript() {
@@ -66,6 +66,27 @@ class TestFixtures {
             from components.java
             artifact(javadocJar)
             artifact(sourcesJar)
+            pom {
+              name = 'Test Project'
+              description = 'Fixture publication used for plugin tests'
+              url = 'https://example.com/test-project'
+              licenses {
+                license {
+                  name = 'MIT'
+                  url = 'https://opensource.org/licenses/MIT'
+                }
+              }
+              developers {
+                developer {
+                  id = 'tester'
+                  name = 'Test User'
+                }
+              }
+              scm {
+                url = 'https://example.com/test-project'
+                connection = 'scm:git:https://example.com/test-project.git'
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
This pull request introduces significant improvements to the Maven Central release plugin, focusing on upfront bundle validation, enhanced error handling, and better reporting of deployment failures. The changes ensure releases are validated before upload, provide clearer feedback on errors, and improve robustness in HTTP interactions with the Central Portal. 

**Bundle Validation Enhancements:**
* Added the new `BundleValidator` class to perform upfront validation of release bundles before upload, including credential checks, required file presence, artifact filename consistency, and POM metadata validation.
* Integrated bundle validation into the `ReleaseTask`, wiring `groupId` and `artifactId` from the publication and failing the task if validation errors are found. [[1]](diffhunk://#diff-6a7db574650a336bdebc86d5cf186fddf5727f48df4feaf2a34680a061db284dR68-R87) [[2]](diffhunk://#diff-03775aa8e9f0161d88bd89befd3bfa416e36b8252609d4fd2e59ed07c816da63R56-R57) [[3]](diffhunk://#diff-6a7db574650a336bdebc86d5cf186fddf5727f48df4feaf2a34680a061db284dR37-R49)

**Central Portal Failure Reporting:**
* Improved reporting of deployment failures by parsing the full deployment status, logging structured validation errors when the deployment state is `FAILED`, and surfacing them to the user.

**HTTP Handling and Error Surfacing:**
* Refactored `WsClient` to check for non-2xx responses, log errors, and throw explicit exceptions with status and body details for all API client calls. [[1]](diffhunk://#diff-73027ea30d9471a752142177df07a0d08ba367e46d6c902fbcce6c451c9131c5R4-R36) [[2]](diffhunk://#diff-73027ea30d9471a752142177df07a0d08ba367e46d6c902fbcce6c451c9131c5L47-R56) [[3]](diffhunk://#diff-73027ea30d9471a752142177df07a0d08ba367e46d6c902fbcce6c451c9131c5R71-R120)
* Updated `CentralPortalClient` to handle upload errors (401/403/422) with clear exceptions and to parse deployment status as a map for improved error handling. [[1]](diffhunk://#diff-005e534ed460e4d8d912767b38d469e5b538530a7c20dae28ec3e1640d88b6cbR51-R57) [[2]](diffhunk://#diff-005e534ed460e4d8d912767b38d469e5b538530a7c20dae28ec3e1640d88b6cbL74-L84)

**Documentation and Versioning:**
* Updated plugin version to `2.1.0` and documented the new features and improvements in `release.md` and `README.md`. [[1]](diffhunk://#diff-8ea7e761f4431f97008201a35a24b3f9cf0d041f0689fcb2e61063f8d43d9517R3-R12) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L24-R24)

These changes collectively make the release process more reliable, transparent, and user-friendly.