### PR TITLE
V2.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ plugins {
   // your other plugins...
    id 'signing'
    id 'maven-publish'
-   id("se.alipsa.nexus-release-plugin") version '2.1.1'
+   id 'se.alipsa.nexus-release-plugin' version '2.1.1'
 }
 
 publishing {

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ plugins {
   // your other plugins...
    id 'signing'
    id 'maven-publish'
-   id("se.alipsa.nexus-release-plugin") version '2.1.0'
+   id("se.alipsa.nexus-release-plugin") version '2.1.1'
 }
 
 publishing {

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
   id 'java-gradle-plugin'
   id 'signing'
   id 'maven-publish'
-  id("com.gradle.plugin-publish") version "2.0.0"
+  id "com.gradle.plugin-publish" version "2.0.0"
   id "com.github.ben-manes.versions" version "0.53.0"
 }
 
@@ -41,8 +41,8 @@ dependencies {
   testImplementation 'org.junit.platform:junit-platform-launcher:6.0.3'
   testImplementation "org.apache.groovy:groovy:${groovyVersion}"
   testImplementation 'com.squareup.okhttp3:mockwebserver:5.3.2'
-  testImplementation 'org.testcontainers:testcontainers:2.0.3' // Use latest
-  testImplementation 'org.testcontainers:junit-jupiter:1.21.4'
+  testImplementation 'org.testcontainers:testcontainers:2.0.3'
+  testImplementation 'org.testcontainers:testcontainers-junit-jupiter:2.0.3'
 }
 
 java {

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ repositories {
 }
 
 dependencies {
-  def groovyVersion = "5.0.4"
+  def groovyVersion = "4.0.30"
   compileOnly "org.apache.groovy:groovy:${groovyVersion}"
 
   testImplementation gradleTestKit()

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = 'se.alipsa'
-version = '2.1.1-SNAPSHOT'
+version = '2.1.1'
 description = 'Automates the release process in Central Portal after signing has completed'
 
 gradlePlugin {

--- a/build.gradle
+++ b/build.gradle
@@ -4,11 +4,11 @@ plugins {
   id 'signing'
   id 'maven-publish'
   id("com.gradle.plugin-publish") version "2.0.0"
-  id "com.github.ben-manes.versions" version "0.52.0"
+  id "com.github.ben-manes.versions" version "0.53.0"
 }
 
 group = 'se.alipsa'
-version = '2.1.0'
+version = '2.1.1-SNAPSHOT'
 description = 'Automates the release process in Central Portal after signing has completed'
 
 gradlePlugin {
@@ -33,16 +33,16 @@ repositories {
 }
 
 dependencies {
-  def groovyVersion = "5.0.0"
+  def groovyVersion = "5.0.4"
   compileOnly "org.apache.groovy:groovy:${groovyVersion}"
 
   testImplementation gradleTestKit()
-  testImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'
-  testImplementation 'org.junit.platform:junit-platform-launcher:1.13.4'
+  testImplementation 'org.junit.jupiter:junit-jupiter:6.0.3'
+  testImplementation 'org.junit.platform:junit-platform-launcher:6.0.3'
   testImplementation "org.apache.groovy:groovy:${groovyVersion}"
-  testImplementation 'com.squareup.okhttp3:mockwebserver:5.1.0'
-  testImplementation 'org.testcontainers:testcontainers:1.21.3' // Use latest
-  testImplementation 'org.testcontainers:junit-jupiter:1.21.3'
+  testImplementation 'com.squareup.okhttp3:mockwebserver:5.3.2'
+  testImplementation 'org.testcontainers:testcontainers:2.0.3' // Use latest
+  testImplementation 'org.testcontainers:junit-jupiter:1.21.4'
 }
 
 java {

--- a/release.md
+++ b/release.md
@@ -6,8 +6,8 @@
 - org.apache.groovy:groovy [5.0.0 -> 4.0.30]
 - org.junit.jupiter:junit-jupiter [5.13.4 -> 6.0.3]
 - org.junit.platform:junit-platform-launcher [1.13.4 -> 6.0.3]
-- org.testcontainers:junit-jupiter [1.21.3 -> 1.21.4]
 - org.testcontainers:testcontainers [1.21.3 -> 2.0.3]
+- org.testcontainers:testcontainers-junit-jupiter [1.21.3 (junit-jupiter) -> 2.0.3]
 - Fix: `release` now uses `mavenPublication.version` (not `project.version`) for snapshot gating and bundle validation, so differing project/publication versions work correctly.
 - Fix: checksums are now regenerated on every bundle build to prevent stale `.md5`/`.sha1` files from being reused.
 - Added compatibility matrix test coverage for Gradle 8.13 and 9.3.1.

--- a/release.md
+++ b/release.md
@@ -1,5 +1,14 @@
 # Release history
 
+## Ver 2.1.1, in progress
+- com.github.ben-manes.versions:com.github.ben-manes.versions.gradle.plugin [0.52.0 -> 0.53.0]
+- com.squareup.okhttp3:mockwebserver [5.1.0 -> 5.3.2]
+- org.apache.groovy:groovy [5.0.0 -> 5.0.4]
+- org.junit.jupiter:junit-jupiter [5.13.4 -> 6.0.3]
+- org.junit.platform:junit-platform-launcher [1.13.4 -> 6.0.3]
+- org.testcontainers:junit-jupiter [1.21.3 -> 1.21.4]
+- org.testcontainers:testcontainers [1.21.3 -> 2.0.3]
+- 
 ## Ver 2.1.0, 2026-02-27
 - Added upfront bundle validation before upload:
   - credentials must be configured

--- a/release.md
+++ b/release.md
@@ -3,12 +3,15 @@
 ## Ver 2.1.1, in progress
 - com.github.ben-manes.versions:com.github.ben-manes.versions.gradle.plugin [0.52.0 -> 0.53.0]
 - com.squareup.okhttp3:mockwebserver [5.1.0 -> 5.3.2]
-- org.apache.groovy:groovy [5.0.0 -> 5.0.4]
+- org.apache.groovy:groovy [5.0.0 -> 4.0.30]
 - org.junit.jupiter:junit-jupiter [5.13.4 -> 6.0.3]
 - org.junit.platform:junit-platform-launcher [1.13.4 -> 6.0.3]
 - org.testcontainers:junit-jupiter [1.21.3 -> 1.21.4]
 - org.testcontainers:testcontainers [1.21.3 -> 2.0.3]
-- 
+- Fix: `release` now uses `mavenPublication.version` (not `project.version`) for snapshot gating and bundle validation, so differing project/publication versions work correctly.
+- Fix: checksums are now regenerated on every bundle build to prevent stale `.md5`/`.sha1` files from being reused.
+- Added compatibility matrix test coverage for Gradle 8.13 and 9.3.1.
+
 ## Ver 2.1.0, 2026-02-27
 - Added upfront bundle validation before upload:
   - credentials must be configured

--- a/src/main/groovy/se/alipsa/gradle/plugin/release/BundleTask.groovy
+++ b/src/main/groovy/se/alipsa/gradle/plugin/release/BundleTask.groovy
@@ -170,10 +170,6 @@ abstract class BundleTask extends DefaultTask {
     void generateChecksum(File file, String algo) {
         String extension = algo.toLowerCase().replace('-', '')
         def checksumFile = new File("${file.absolutePath}.${extension}")
-        if (checksumFile.exists()) {
-            logger.debug("${checksumFile.name} already exists")
-            return
-        }
         def digest = MessageDigest.getInstance(algo)
         file.withInputStream { is ->
             new DigestOutputStream(OutputStream.nullOutputStream(), digest)
@@ -181,6 +177,6 @@ abstract class BundleTask extends DefaultTask {
         }
         def hash = digest.digest().encodeHex().toString()
         checksumFile.text = hash
-        logger.debug("Generated ${algo} for ${file.name} → ${checksumFile.name}")
+        logger.debug("Generated ${algo} for ${file.name} -> ${checksumFile.name}")
     }
 }

--- a/src/main/groovy/se/alipsa/gradle/plugin/release/NexusReleasePlugin.groovy
+++ b/src/main/groovy/se/alipsa/gradle/plugin/release/NexusReleasePlugin.groovy
@@ -51,7 +51,7 @@ class NexusReleasePlugin implements Plugin<Project> {
             task.bundleFile.set(bundleTask.flatMap { it.bundleFile })
 
             // Wire project metadata
-            task.projectVersion.set(project.provider { project.version.toString() })
+            task.publicationVersion.set(extension.mavenPublication.map { it.version })
             task.projectName.set(project.provider { project.name })
             task.groupId.set(extension.mavenPublication.map { it.groupId })
             task.artifactId.set(extension.mavenPublication.map { it.artifactId })

--- a/src/main/groovy/se/alipsa/gradle/plugin/release/ReleaseTask.groovy
+++ b/src/main/groovy/se/alipsa/gradle/plugin/release/ReleaseTask.groovy
@@ -25,7 +25,7 @@ abstract class ReleaseTask extends DefaultTask {
     abstract RegularFileProperty getBundleFile()
 
     @Input
-    abstract Property<String> getProjectVersion()
+    abstract Property<String> getPublicationVersion()
 
     @Input
     abstract Property<String> getProjectName()
@@ -54,7 +54,7 @@ abstract class ReleaseTask extends DefaultTask {
 
     @TaskAction
     void release() {
-        String version = projectVersion.get()
+        String version = publicationVersion.get()
         if (version.endsWith("-SNAPSHOT")) {
             logger.quiet("Alipsa Nexus Release Plugin: A snapshot cannot be released, publish is enough (or maybe you forgot to change the version?)")
             return

--- a/src/test/groovy/se/alipsa/gradle/plugin/release/GradleCompatibilityMatrixTest.groovy
+++ b/src/test/groovy/se/alipsa/gradle/plugin/release/GradleCompatibilityMatrixTest.groovy
@@ -16,20 +16,21 @@ class GradleCompatibilityMatrixTest {
   @ValueSource(strings = ['8.13', '9.3.1'])
   void bundleTaskIsCompatibleAcrossSupportedGradleVersions(String gradleVersion) throws IOException {
     File testProjectDir = TestFixtures.createTestProject()
+    try {
+      BuildResult result = GradleRunner.create()
+          .withProjectDir(testProjectDir)
+          .withGradleVersion(gradleVersion)
+          .withArguments('bundle')
+          .withPluginClasspath()
+          .forwardOutput()
+          .build()
 
-    BuildResult result = GradleRunner.create()
-        .withProjectDir(testProjectDir)
-        .withGradleVersion(gradleVersion)
-        .withArguments('bundle')
-        .withPluginClasspath()
-        .forwardOutput()
-        .build()
-
-    assertEquals(TaskOutcome.SUCCESS, result.task(':bundle').outcome)
-    File zipFile = new File(testProjectDir, 'build/zips/test-project-1.0.0-bundle.zip')
-    assertTrue(zipFile.exists(), "ZIP file should be created when running on Gradle ${gradleVersion}")
-
-    AntBuilder ant = new AntBuilder()
-    ant.delete dir: testProjectDir.parentFile
+      assertEquals(TaskOutcome.SUCCESS, result.task(':bundle').outcome)
+      File zipFile = new File(testProjectDir, 'build/zips/test-project-1.0.0-bundle.zip')
+      assertTrue(zipFile.exists(), "ZIP file should be created when running on Gradle ${gradleVersion}")
+    } finally {
+      AntBuilder ant = new AntBuilder()
+      ant.delete dir: testProjectDir.parentFile
+    }
   }
 }

--- a/src/test/groovy/se/alipsa/gradle/plugin/release/GradleCompatibilityMatrixTest.groovy
+++ b/src/test/groovy/se/alipsa/gradle/plugin/release/GradleCompatibilityMatrixTest.groovy
@@ -1,0 +1,35 @@
+package se.alipsa.gradle.plugin.release
+
+import groovy.ant.AntBuilder
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertTrue
+
+class GradleCompatibilityMatrixTest {
+
+  @ParameterizedTest(name = "bundle works on Gradle {0}")
+  @ValueSource(strings = ['8.13', '9.3.1'])
+  void bundleTaskIsCompatibleAcrossSupportedGradleVersions(String gradleVersion) throws IOException {
+    File testProjectDir = TestFixtures.createTestProject()
+
+    BuildResult result = GradleRunner.create()
+        .withProjectDir(testProjectDir)
+        .withGradleVersion(gradleVersion)
+        .withArguments('bundle')
+        .withPluginClasspath()
+        .forwardOutput()
+        .build()
+
+    assertEquals(TaskOutcome.SUCCESS, result.task(':bundle').outcome)
+    File zipFile = new File(testProjectDir, 'build/zips/test-project-1.0.0-bundle.zip')
+    assertTrue(zipFile.exists(), "ZIP file should be created when running on Gradle ${gradleVersion}")
+
+    AntBuilder ant = new AntBuilder()
+    ant.delete dir: testProjectDir.parentFile
+  }
+}

--- a/src/test/groovy/se/alipsa/gradle/plugin/release/ReleasePluginTest.groovy
+++ b/src/test/groovy/se/alipsa/gradle/plugin/release/ReleasePluginTest.groovy
@@ -157,4 +157,28 @@ base {
     AntBuilder ant = new AntBuilder()
     ant.delete dir: testProjectDir.parentFile
   }
+
+  @Test
+  void releaseUsesPublicationVersionWhenProjectVersionDiffers() throws IOException {
+    String buildScript = TestFixtures.createBuildScript()
+        .replace("version = '1.0.0'", "version = '1.0.0-SNAPSHOT'")
+        .replace("artifact(sourcesJar)", "artifact(sourcesJar)\n            version = '1.0.0'")
+        .replace("userName = 'sonaTypeUserName'", "userName = ''")
+        .replace("password = 'sonaTypePassword'", "password = ''")
+
+    File testProjectDir = TestFixtures.createTestProject(buildScript)
+
+    BuildResult result = GradleRunner.create()
+        .withProjectDir(testProjectDir)
+        .withArguments("release")
+        .withPluginClasspath()
+        .forwardOutput()
+        .buildAndFail()
+
+    assertTrue(result.output.contains("Credentials not configured. Add the following to ~/.gradle/gradle.properties"))
+    assertFalse(result.output.contains("A snapshot cannot be released"))
+
+    AntBuilder ant = new AntBuilder()
+    ant.delete dir: testProjectDir.parentFile
+  }
 }


### PR DESCRIPTION
This pull request updates the `se.alipsa.nexus-release-plugin` to version 2.1.1 and introduces several improvements and fixes to the release process. The most significant changes are the switch to using `mavenPublication.version` for snapshot gating and bundle validation, regeneration of checksums on every build, and expanded test coverage for Gradle compatibility. The update also includes dependency upgrades and new tests to ensure correct behavior when project and publication versions differ.

Release process improvements:

* The `release` task now uses `mavenPublication.version` instead of `project.version` for snapshot gating and bundle validation, allowing differing project and publication versions to work correctly. (`src/main/groovy/se/alipsa/gradle/plugin/release/NexusReleasePlugin.groovy`, `src/main/groovy/se/alipsa/gradle/plugin/release/ReleaseTask.groovy`, [[1]](diffhunk://#diff-f64593c6beea3a8385cc9806f574bcd5d736e925569c46ab412b3818d5687745R160-R183) [[2]](diffhunk://#diff-8ea7e761f4431f97008201a35a24b3f9cf0d041f0689fcb2e61063f8d43d9517R3-R14) [[3]](diffhunk://#diff-03775aa8e9f0161d88bd89befd3bfa416e36b8252609d4fd2e59ed07c816da63L54-R54) [[4]](diffhunk://#diff-6a7db574650a336bdebc86d5cf186fddf5727f48df4feaf2a34680a061db284dL28-R28) [[5]](diffhunk://#diff-6a7db574650a336bdebc86d5cf186fddf5727f48df4feaf2a34680a061db284dL57-R57)
* Checksums (`.md5`, `.sha1`) are now regenerated on every bundle build to prevent stale files from being reused. (`src/main/groovy/se/alipsa/gradle/plugin/release/BundleTask.groovy`, [[1]](diffhunk://#diff-dcf9af5e4aeb87f18ff7e740775a78ff2fd1a3ea79235f0ef77c72d968cf0299L173-R180) [[2]](diffhunk://#diff-8ea7e761f4431f97008201a35a24b3f9cf0d041f0689fcb2e61063f8d43d9517R3-R14)

Testing and compatibility:

* Added compatibility matrix test coverage for Gradle 8.13 and 9.3.1 to ensure the plugin works across supported Gradle versions. (`src/test/groovy/se/alipsa/gradle/plugin/release/GradleCompatibilityMatrixTest.groovy`, [[1]](diffhunk://#diff-1b2dcce7b4a908667f5418021618195718dcb1a0885cf4dd7d720019c51fd70eR1-R35) [[2]](diffhunk://#diff-8ea7e761f4431f97008201a35a24b3f9cf0d041f0689fcb2e61063f8d43d9517R3-R14)
* Added a new test to verify that the `release` task uses the publication version when it differs from the project version. (`src/test/groovy/se/alipsa/gradle/plugin/release/ReleasePluginTest.groovy`, [src/test/groovy/se/alipsa/gradle/plugin/release/ReleasePluginTest.groovyR160-R183](diffhunk://#diff-f64593c6beea3a8385cc9806f574bcd5d736e925569c46ab412b3818d5687745R160-R183))

Dependency upgrades:

* Updated multiple dependencies to their latest versions, including `com.github.ben-manes.versions`, `mockwebserver`, `groovy`, `junit-jupiter`, `junit-platform-launcher`, and `testcontainers`. (`release.md`, [release.mdR3-R14](diffhunk://#diff-8ea7e761f4431f97008201a35a24b3f9cf0d041f0689fcb2e61063f8d43d9517R3-R14))

Plugin version update:

* Updated the `se.alipsa.nexus-release-plugin` version from 2.1.0 to 2.1.1 in `README.md`.