### PR TITLE
Add latestGithubRelease task and improve latestMavenVersions diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,13 +190,23 @@ nexusReleasePlugin {
 }
 ```
 
-For GitHub Enterprise, override the API base URL:
+For GitHub Enterprise, the repository is auto-detected from the Enterprise remote URL (e.g. `https://github.example.com/owner/repo.git`). You only need to set the API base URL:
 
 ```groovy
 nexusReleasePlugin {
    githubApiBaseUrl = "https://github.example.com/api/v3"
 }
 ```
+
+If auto-detection does not work (e.g. non-standard hosting or no remote configured), set the repository slug explicitly:
+
+```groovy
+nexusReleasePlugin {
+   githubRepo = "owner/repo"
+}
+```
+
+An explicit `githubRepo` always takes priority over auto-detection.
 
 ## Building the Plugin
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The plugin adds these tasks:
 - `bundle`: creates the Maven Central bundle from the configured publication.
 - `release`: validates and uploads the bundle to Central Portal.
 - `latestMavenVersions`: lists the latest published version for the current project, and when run on the root project also for published subprojects that use this plugin.
+- `latestGithubRelease`: displays the latest GitHub release tag for this repository (auto-detected from the `origin` remote).
 
 If you want to publish to another url that behaves just like the Central Publishing API, you 
 can set the property `nexusUrl` in the nexusReleasePlugin e.g:
@@ -153,6 +154,47 @@ If you need `latestMavenVersions` to query another Maven-compatible repository, 
 nexusReleasePlugin {
    metadataBaseUrl = "https://repo1.maven.org/maven2"
    mavenPublication = publishing.publications.maven
+}
+```
+
+When the artifact has not yet been published, the output includes the coordinates that were searched so you can verify the configuration is correct:
+```
+my-project (se.alipsa:my-project): not found in metadata repository
+```
+
+## The latestGithubRelease task
+
+The `latestGithubRelease` task displays the latest GitHub release tag for this repository.
+The repository is auto-detected from the `origin` remote in `.git/config` — no configuration needed for public repos.
+
+Run:
+```
+./gradlew latestGithubRelease
+```
+
+Example output:
+```
+Alipsa/my-project: v1.2.3
+```
+
+If no releases exist yet:
+```
+Alipsa/my-project: no releases found
+```
+
+For private repositories, or to avoid GitHub API rate limits, set a token:
+
+```groovy
+nexusReleasePlugin {
+   githubToken = githubAccessToken  // from gradle.properties
+}
+```
+
+For GitHub Enterprise, override the API base URL:
+
+```groovy
+nexusReleasePlugin {
+   githubApiBaseUrl = "https://github.example.com/api/v3"
 }
 ```
 

--- a/src/main/groovy/se/alipsa/gradle/plugin/release/LatestGithubReleaseTask.groovy
+++ b/src/main/groovy/se/alipsa/gradle/plugin/release/LatestGithubReleaseTask.groovy
@@ -43,14 +43,36 @@ abstract class LatestGithubReleaseTask extends DefaultTask {
 
         String baseUrl = githubApiBaseUrl.get().replaceAll('/+$', '')
         String url = "${baseUrl}/repos/${repo}/releases/latest"
+        String token = githubToken.orNull ?: resolveGhToken(baseUrl)
 
         try {
-            String tag = fetchLatestRelease(url, githubToken.orNull)
+            String tag = fetchLatestRelease(url, token)
             logger.quiet("${repo}: ${tag}")
         } catch (FileNotFoundException ignored) {
             logger.quiet("${repo}: no releases found")
         } catch (Exception e) {
             logger.quiet("${repo}: error querying GitHub API (${e.message})")
+        }
+    }
+
+    @CompileStatic
+    private static String resolveGhToken(String apiBaseUrl) {
+        try {
+            String ghBin = System.getProperty('se.alipsa.nexus-release-plugin.ghBin', 'gh')
+            List<String> cmd = new ArrayList<>([ghBin, 'auth', 'token'])
+            if (apiBaseUrl != 'https://api.github.com') {
+                String host = URI.create(apiBaseUrl).host
+                if (host) {
+                    cmd.add('--hostname')
+                    cmd.add(host)
+                }
+            }
+            Process process = new ProcessBuilder(cmd).start()
+            String token = process.inputStream.text.trim()
+            process.waitFor()
+            return token ?: null
+        } catch (Exception ignored) {
+            return null
         }
     }
 

--- a/src/main/groovy/se/alipsa/gradle/plugin/release/LatestGithubReleaseTask.groovy
+++ b/src/main/groovy/se/alipsa/gradle/plugin/release/LatestGithubReleaseTask.groovy
@@ -1,0 +1,84 @@
+package se.alipsa.gradle.plugin.release
+
+import groovy.json.JsonSlurper
+import groovy.transform.CompileDynamic
+import groovy.transform.CompileStatic
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+
+/**
+ * Displays the latest GitHub release for this repository, detected from the git remote.
+ */
+@CompileStatic
+@DisableCachingByDefault(because = "Queries external GitHub API and should always execute")
+abstract class LatestGithubReleaseTask extends DefaultTask {
+
+    @Input
+    @Optional
+    abstract Property<String> getRepoCoordinates()
+
+    @Input
+    abstract Property<String> getGithubApiBaseUrl()
+
+    @Input
+    @Optional
+    abstract Property<String> getGithubToken()
+
+    LatestGithubReleaseTask() {
+        group = 'help'
+        description = 'Displays the latest GitHub release for this repository'
+    }
+
+    @TaskAction
+    void listLatestRelease() {
+        String repo = repoCoordinates.orNull
+        if (!repo) {
+            logger.quiet('No GitHub repository detected. Ensure this project has a GitHub remote named "origin".')
+            return
+        }
+
+        String baseUrl = githubApiBaseUrl.get().replaceAll('/+$', '')
+        String url = "${baseUrl}/repos/${repo}/releases/latest"
+
+        try {
+            String tag = fetchLatestRelease(url, githubToken.orNull)
+            logger.quiet("${repo}: ${tag}")
+        } catch (FileNotFoundException ignored) {
+            logger.quiet("${repo}: no releases found")
+        } catch (Exception e) {
+            logger.quiet("${repo}: error querying GitHub API (${e.message})")
+        }
+    }
+
+    @CompileDynamic
+    private static String fetchLatestRelease(String url, String token) {
+        URLConnection connection = URI.create(url).toURL().openConnection()
+        connection.connectTimeout = 5000
+        connection.readTimeout = 5000
+        connection.setRequestProperty('Accept', 'application/vnd.github+json')
+        connection.setRequestProperty('User-Agent', 'se.alipsa.nexus-release-plugin')
+        if (token) {
+            connection.setRequestProperty('Authorization', "Bearer ${token}")
+        }
+
+        if (connection instanceof HttpURLConnection) {
+            HttpURLConnection http = (HttpURLConnection) connection
+            int responseCode = http.responseCode
+            if (responseCode == HttpURLConnection.HTTP_NOT_FOUND) {
+                throw new FileNotFoundException(url)
+            }
+            if (responseCode >= 400) {
+                throw new IOException("HTTP ${responseCode}")
+            }
+        }
+
+        connection.inputStream.withCloseable { InputStream stream ->
+            def json = new JsonSlurper().parse(stream)
+            return json.tag_name as String
+        }
+    }
+}

--- a/src/main/groovy/se/alipsa/gradle/plugin/release/LatestMavenVersionsTask.groovy
+++ b/src/main/groovy/se/alipsa/gradle/plugin/release/LatestMavenVersionsTask.groovy
@@ -44,12 +44,12 @@ abstract class LatestMavenVersionsTask extends DefaultTask {
                 if (latest) {
                     logger.quiet("${module.displayName}: ${module.groupId}:${module.artifactId}:${latest}")
                 } else {
-                    logger.quiet("${module.displayName}: no release version found")
+                    logger.quiet("${module.displayName}: no release version found (${module.groupId}:${module.artifactId})")
                 }
             } catch (FileNotFoundException ignored) {
-                logger.quiet("${module.displayName}: not found in metadata repository")
+                logger.quiet("${module.displayName}: not found in metadata repository (${module.groupId}:${module.artifactId})")
             } catch (Exception e) {
-                logger.quiet("${module.displayName}: error querying metadata repository (${e.message})")
+                logger.quiet("${module.displayName}: error querying metadata repository for ${module.groupId}:${module.artifactId} (${e.message})")
             }
         }
     }

--- a/src/main/groovy/se/alipsa/gradle/plugin/release/NexusReleasePlugin.groovy
+++ b/src/main/groovy/se/alipsa/gradle/plugin/release/NexusReleasePlugin.groovy
@@ -80,9 +80,9 @@ class NexusReleasePlugin implements Plugin<Project> {
         TaskProvider<LatestGithubReleaseTask> latestGithubReleaseTask = project.tasks.register('latestGithubRelease', LatestGithubReleaseTask) { LatestGithubReleaseTask task ->
             task.githubApiBaseUrl.set(extension.githubApiBaseUrl)
             task.githubToken.set(extension.githubToken)
-            task.repoCoordinates.set(project.provider {
+            task.repoCoordinates.set(extension.githubRepo.orElse(project.provider {
                 detectGithubRepo(project.rootProject.projectDir)
-            })
+            }))
         }
 
         // Expose tasks via the extension for external access
@@ -183,9 +183,9 @@ class NexusReleasePlugin implements Plugin<Project> {
 
     private static String parseGithubCoordinates(String remoteUrl) {
         if (!remoteUrl) return null
-        Matcher ssh = Pattern.compile('^git@github\\.com:(.+?)(?:\\.git)?$').matcher(remoteUrl)
+        Matcher ssh = Pattern.compile('^git@[^:]+:(.+?)(?:\\.git)?$').matcher(remoteUrl)
         if (ssh.matches()) return ssh.group(1)
-        Matcher https = Pattern.compile('^https?://github\\.com/(.+?)(?:\\.git)?$').matcher(remoteUrl)
+        Matcher https = Pattern.compile('^https?://[^/]+/(.+?)(?:\\.git)?$').matcher(remoteUrl)
         if (https.matches()) return https.group(1)
         return null
     }

--- a/src/main/groovy/se/alipsa/gradle/plugin/release/NexusReleasePlugin.groovy
+++ b/src/main/groovy/se/alipsa/gradle/plugin/release/NexusReleasePlugin.groovy
@@ -188,8 +188,11 @@ class NexusReleasePlugin implements Plugin<Project> {
         String apiHost = URI.create(apiBaseUrl).host ?: 'api.github.com'
         // For api.github.com the remote host is github.com; for Enterprise the api and git hosts match
         String expectedRemoteHost = (apiHost == 'api.github.com') ? 'github.com' : apiHost
-        Matcher ssh = Pattern.compile('^git@([^:]+):(.+?)(?:\\.git)?$').matcher(remoteUrl)
-        if (ssh.matches() && ssh.group(1) == expectedRemoteHost) return ssh.group(2)
+        Matcher sshScp = Pattern.compile('^git@([^:]+):(.+?)(?:\\.git)?$').matcher(remoteUrl)
+        if (sshScp.matches() && sshScp.group(1) == expectedRemoteHost) return sshScp.group(2)
+        // ssh://[user@]host[:port]/owner/repo — strip optional user@ and port
+        Matcher sshUrl = Pattern.compile('^ssh://(?:[^@]+@)?([^/:]+)(?::\\d+)?/(.+?)(?:\\.git)?$').matcher(remoteUrl)
+        if (sshUrl.matches() && sshUrl.group(1) == expectedRemoteHost) return sshUrl.group(2)
         // Strip port from remote host so http://localhost:8080/x matches API host 'localhost'
         Matcher https = Pattern.compile('^https?://([^/:]+)(?::\\d+)?/(.+?)(?:\\.git)?$').matcher(remoteUrl)
         if (https.matches() && https.group(1) == expectedRemoteHost) return https.group(2)

--- a/src/main/groovy/se/alipsa/gradle/plugin/release/NexusReleasePlugin.groovy
+++ b/src/main/groovy/se/alipsa/gradle/plugin/release/NexusReleasePlugin.groovy
@@ -80,9 +80,11 @@ class NexusReleasePlugin implements Plugin<Project> {
         TaskProvider<LatestGithubReleaseTask> latestGithubReleaseTask = project.tasks.register('latestGithubRelease', LatestGithubReleaseTask) { LatestGithubReleaseTask task ->
             task.githubApiBaseUrl.set(extension.githubApiBaseUrl)
             task.githubToken.set(extension.githubToken)
-            task.repoCoordinates.set(extension.githubRepo.orElse(project.provider {
-                detectGithubRepo(project.rootProject.projectDir)
-            }))
+            task.repoCoordinates.set(extension.githubRepo.orElse(
+                extension.githubApiBaseUrl.map { String apiBaseUrl ->
+                    detectGithubRepo(project.rootProject.projectDir, apiBaseUrl)
+                }
+            ))
         }
 
         // Expose tasks via the extension for external access
@@ -122,9 +124,9 @@ class NexusReleasePlugin implements Plugin<Project> {
         "${displayName}\t${groupId}\t${artifactId}"
     }
 
-    private static String detectGithubRepo(File projectDir) {
+    private static String detectGithubRepo(File projectDir, String apiBaseUrl) {
         String originUrl = findOriginUrl(projectDir)
-        return originUrl ? parseGithubCoordinates(originUrl) : null
+        return originUrl ? parseGithubCoordinates(originUrl, apiBaseUrl) : null
     }
 
     private static String findOriginUrl(File startDir) {
@@ -181,12 +183,16 @@ class NexusReleasePlugin implements Plugin<Project> {
         return null
     }
 
-    private static String parseGithubCoordinates(String remoteUrl) {
+    private static String parseGithubCoordinates(String remoteUrl, String apiBaseUrl) {
         if (!remoteUrl) return null
-        Matcher ssh = Pattern.compile('^git@[^:]+:(.+?)(?:\\.git)?$').matcher(remoteUrl)
-        if (ssh.matches()) return ssh.group(1)
-        Matcher https = Pattern.compile('^https?://[^/]+/(.+?)(?:\\.git)?$').matcher(remoteUrl)
-        if (https.matches()) return https.group(1)
+        String apiHost = URI.create(apiBaseUrl).host ?: 'api.github.com'
+        // For api.github.com the remote host is github.com; for Enterprise the api and git hosts match
+        String expectedRemoteHost = (apiHost == 'api.github.com') ? 'github.com' : apiHost
+        Matcher ssh = Pattern.compile('^git@([^:]+):(.+?)(?:\\.git)?$').matcher(remoteUrl)
+        if (ssh.matches() && ssh.group(1) == expectedRemoteHost) return ssh.group(2)
+        // Strip port from remote host so http://localhost:8080/x matches API host 'localhost'
+        Matcher https = Pattern.compile('^https?://([^/:]+)(?::\\d+)?/(.+?)(?:\\.git)?$').matcher(remoteUrl)
+        if (https.matches() && https.group(1) == expectedRemoteHost) return https.group(2)
         return null
     }
 

--- a/src/main/groovy/se/alipsa/gradle/plugin/release/NexusReleasePlugin.groovy
+++ b/src/main/groovy/se/alipsa/gradle/plugin/release/NexusReleasePlugin.groovy
@@ -7,6 +7,9 @@ import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.tasks.TaskProvider
 
+import java.util.regex.Matcher
+import java.util.regex.Pattern
+
 /**
  * This plugin is an alternative to the nexus publish plugin which for some of
  * my more complex projects did not do what I wanted it to do.
@@ -74,10 +77,19 @@ class NexusReleasePlugin implements Plugin<Project> {
             })
         }
 
+        TaskProvider<LatestGithubReleaseTask> latestGithubReleaseTask = project.tasks.register('latestGithubRelease', LatestGithubReleaseTask) { LatestGithubReleaseTask task ->
+            task.githubApiBaseUrl.set(extension.githubApiBaseUrl)
+            task.githubToken.set(extension.githubToken)
+            task.repoCoordinates.set(project.provider {
+                detectGithubRepo(project.rootProject.projectDir)
+            })
+        }
+
         // Expose tasks via the extension for external access
         extension.bundleTask = bundleTask
         extension.releaseTask = releaseTask
         extension.latestMavenVersionsTask = latestMavenVersionsTask
+        extension.latestGithubReleaseTask = latestGithubReleaseTask
     }
 
     private static List<String> collectPublishedModules(Project currentProject) {
@@ -108,6 +120,74 @@ class NexusReleasePlugin implements Plugin<Project> {
 
         String displayName = candidate == candidate.rootProject ? candidate.name : candidate.path
         "${displayName}\t${groupId}\t${artifactId}"
+    }
+
+    private static String detectGithubRepo(File projectDir) {
+        String originUrl = findOriginUrl(projectDir)
+        return originUrl ? parseGithubCoordinates(originUrl) : null
+    }
+
+    private static String findOriginUrl(File startDir) {
+        File dir = startDir
+        while (dir != null) {
+            File git = new File(dir, '.git')
+            if (git.exists()) {
+                String url = readOriginUrl(git)
+                if (url) return url
+            }
+            dir = dir.parentFile
+        }
+        return null
+    }
+
+    private static String readOriginUrl(File git) {
+        try {
+            File configFile
+            if (git.isDirectory()) {
+                configFile = new File(git, 'config')
+            } else if (git.isFile()) {
+                // Worktree: .git is a file containing "gitdir: /path/to/.git/worktrees/branch"
+                String ref = git.text.trim()
+                if (!ref.startsWith('gitdir:')) return null
+                File worktreeGitDir = new File(ref.substring('gitdir:'.length()).trim())
+                File commondirFile = new File(worktreeGitDir, 'commondir')
+                if (!commondirFile.exists()) return null
+                String commonPath = commondirFile.text.trim()
+                File commonDirFile = new File(commonPath)
+                File commonDir = commonDirFile.isAbsolute() ? commonDirFile : new File(worktreeGitDir, commonPath)
+                configFile = new File(commonDir, 'config')
+            } else {
+                return null
+            }
+            if (!configFile?.exists()) return null
+            return parseOriginUrlFromConfig(configFile.text)
+        } catch (IOException ignored) {
+            return null
+        }
+    }
+
+    private static String parseOriginUrlFromConfig(String config) {
+        boolean inOriginSection = false
+        for (String line : config.split('\n')) {
+            String trimmed = line.trim()
+            if (trimmed == '[remote "origin"]') {
+                inOriginSection = true
+            } else if (trimmed.startsWith('[')) {
+                inOriginSection = false
+            } else if (inOriginSection && trimmed.startsWith('url =')) {
+                return trimmed.substring(trimmed.indexOf('=') + 1).trim()
+            }
+        }
+        return null
+    }
+
+    private static String parseGithubCoordinates(String remoteUrl) {
+        if (!remoteUrl) return null
+        Matcher ssh = Pattern.compile('^git@github\\.com:(.+?)(?:\\.git)?$').matcher(remoteUrl)
+        if (ssh.matches()) return ssh.group(1)
+        Matcher https = Pattern.compile('^https?://github\\.com/(.+?)(?:\\.git)?$').matcher(remoteUrl)
+        if (https.matches()) return https.group(1)
+        return null
     }
 
     private static MavenPublication publicationFor(Project candidate) {

--- a/src/main/groovy/se/alipsa/gradle/plugin/release/NexusReleasePluginExtension.groovy
+++ b/src/main/groovy/se/alipsa/gradle/plugin/release/NexusReleasePluginExtension.groovy
@@ -21,6 +21,7 @@ class NexusReleasePluginExtension {
     final Property<Integer> initialStatusCheckDelaySeconds
     final Property<String> githubApiBaseUrl
     final Property<String> githubToken
+    final Property<String> githubRepo
 
     // References to tasks with proper types
     TaskProvider<BundleTask> bundleTask
@@ -40,6 +41,7 @@ class NexusReleasePluginExtension {
         initialStatusCheckDelaySeconds = objects.property(Integer).convention(10)
         githubApiBaseUrl = objects.property(String).convention('https://api.github.com')
         githubToken = objects.property(String)
+        githubRepo = objects.property(String)
     }
 
     void setNexusUrl(String url) {
@@ -80,6 +82,10 @@ class NexusReleasePluginExtension {
 
     void setGithubToken(String token) {
         githubToken.set(token)
+    }
+
+    void setGithubRepo(String repo) {
+        githubRepo.set(repo)
     }
 
 }

--- a/src/main/groovy/se/alipsa/gradle/plugin/release/NexusReleasePluginExtension.groovy
+++ b/src/main/groovy/se/alipsa/gradle/plugin/release/NexusReleasePluginExtension.groovy
@@ -19,11 +19,14 @@ class NexusReleasePluginExtension {
     final Property<Integer> statusCheckRetries
     final Property<Integer> statusCheckIntervalSeconds
     final Property<Integer> initialStatusCheckDelaySeconds
+    final Property<String> githubApiBaseUrl
+    final Property<String> githubToken
 
     // References to tasks with proper types
     TaskProvider<BundleTask> bundleTask
     TaskProvider<ReleaseTask> releaseTask
     TaskProvider<LatestMavenVersionsTask> latestMavenVersionsTask
+    TaskProvider<LatestGithubReleaseTask> latestGithubReleaseTask
 
     @Inject
     NexusReleasePluginExtension(ObjectFactory objects) {
@@ -35,6 +38,8 @@ class NexusReleasePluginExtension {
         statusCheckRetries = objects.property(Integer).convention(10)
         statusCheckIntervalSeconds = objects.property(Integer).convention(10)
         initialStatusCheckDelaySeconds = objects.property(Integer).convention(10)
+        githubApiBaseUrl = objects.property(String).convention('https://api.github.com')
+        githubToken = objects.property(String)
     }
 
     void setNexusUrl(String url) {
@@ -67,6 +72,14 @@ class NexusReleasePluginExtension {
 
     void setInitialStatusCheckDelaySeconds(Integer seconds) {
         initialStatusCheckDelaySeconds.set(seconds)
+    }
+
+    void setGithubApiBaseUrl(String url) {
+        githubApiBaseUrl.set(url)
+    }
+
+    void setGithubToken(String token) {
+        githubToken.set(token)
     }
 
 }

--- a/src/test/groovy/se/alipsa/gradle/plugin/release/ReleasePluginTest.groovy
+++ b/src/test/groovy/se/alipsa/gradle/plugin/release/ReleasePluginTest.groovy
@@ -283,7 +283,8 @@ base {
     server.setDispatcher(new GithubReleaseDispatcher(repoSlug, expectedTag))
 
     String githubApiBaseUrl = server.url('/').toString()
-    File testProjectDir = TestFixtures.createGithubProject(githubApiBaseUrl, repoSlug)
+    String remoteUrl = "${server.url('/')}${repoSlug}.git"
+    File testProjectDir = TestFixtures.createGithubProject(githubApiBaseUrl, repoSlug, remoteUrl)
     try {
       BuildResult firstRun = GradleRunner.create()
           .withProjectDir(testProjectDir)
@@ -318,7 +319,8 @@ base {
     server.setDispatcher(new GithubReleaseDispatcher(repoSlug, null))
 
     String githubApiBaseUrl = server.url('/').toString()
-    File testProjectDir = TestFixtures.createGithubProject(githubApiBaseUrl, repoSlug)
+    String remoteUrl = "${server.url('/')}${repoSlug}.git"
+    File testProjectDir = TestFixtures.createGithubProject(githubApiBaseUrl, repoSlug, remoteUrl)
     try {
       BuildResult result = GradleRunner.create()
           .withProjectDir(testProjectDir)
@@ -342,7 +344,8 @@ base {
     server.setDispatcher(new GithubReleaseDispatcher(repoSlug, expectedTag))
 
     String githubApiBaseUrl = server.url('/').toString()
-    String enterpriseRemote = "https://github.example.com/${repoSlug}.git"
+    // Remote host must match the API host (localhost here); the "enterprise" aspect is the custom API URL
+    String enterpriseRemote = "${server.url('/')}${repoSlug}.git"
     File testProjectDir = TestFixtures.createGithubProject(githubApiBaseUrl, repoSlug, enterpriseRemote)
     try {
       BuildResult result = GradleRunner.create()
@@ -381,6 +384,84 @@ base {
           "Expected output to contain '${repoSlug}: ${expectedTag}' but was:\n${result.output}")
     } finally {
       cleanupTestProject(testProjectDir)
+    }
+  }
+
+  @Test
+  void latestGithubReleaseUsesGhCliTokenWhenAvailable() throws IOException {
+    String repoSlug = 'owner/auth-repo'
+    String expectedTag = 'v5.0.0'
+    String fakeToken = 'test-gh-token-abc123'
+    server.setDispatcher(new AuthRequiredGithubReleaseDispatcher(repoSlug, expectedTag, fakeToken))
+
+    String githubApiBaseUrl = server.url('/').toString()
+    String remoteUrl = "${server.url('/')}${repoSlug}.git"
+    File testProjectDir = TestFixtures.createGithubProjectWithFakeGh(githubApiBaseUrl, repoSlug, fakeToken, remoteUrl)
+    try {
+      String ghBinPath = new File(testProjectDir, 'bin/gh').absolutePath
+      BuildResult result = GradleRunner.create()
+          .withProjectDir(testProjectDir)
+          .withArguments("-Dse.alipsa.nexus-release-plugin.ghBin=${ghBinPath}", 'latestGithubRelease')
+          .withPluginClasspath()
+          .forwardOutput()
+          .build()
+
+      assertEquals(TaskOutcome.SUCCESS, result.task(':latestGithubRelease').outcome)
+      assertTrue(result.output.contains("${repoSlug}: ${expectedTag}"),
+          "Expected output to contain '${repoSlug}: ${expectedTag}' but was:\n${result.output}")
+    } finally {
+      cleanupTestProject(testProjectDir)
+    }
+  }
+
+  @Test
+  void latestGithubReleaseIgnoresNonGithubRemoteWhenUsingDefaultApi() throws IOException {
+    // A GitLab remote with the default api.github.com should produce "no repo detected", not a false positive.
+    // Since repoCoordinates is null, no HTTP call is made — safe to use the real API URL here.
+    String repoSlug = 'owner/non-github-repo'
+    File testProjectDir = TestFixtures.createGithubProject(
+        'https://api.github.com', repoSlug, "https://gitlab.com/${repoSlug}.git")
+    try {
+      BuildResult result = GradleRunner.create()
+          .withProjectDir(testProjectDir)
+          .withArguments('latestGithubRelease')
+          .withPluginClasspath()
+          .forwardOutput()
+          .build()
+
+      assertEquals(TaskOutcome.SUCCESS, result.task(':latestGithubRelease').outcome)
+      assertTrue(result.output.contains('No GitHub repository detected'),
+          "Expected 'No GitHub repository detected' for non-GitHub remote but got:\n${result.output}")
+    } finally {
+      cleanupTestProject(testProjectDir)
+    }
+  }
+
+  private static final class AuthRequiredGithubReleaseDispatcher extends Dispatcher {
+    private final String repoSlug
+    private final String tagName
+    private final String expectedToken
+
+    AuthRequiredGithubReleaseDispatcher(String repoSlug, String tagName, String expectedToken) {
+      this.repoSlug = repoSlug
+      this.tagName = tagName
+      this.expectedToken = expectedToken
+    }
+
+    @Override
+    MockResponse dispatch(RecordedRequest request) {
+      String auth = request.getHeader('Authorization')
+      if (auth != "Bearer ${expectedToken}") {
+        return new MockResponse().setResponseCode(401).setBody('{"message":"Requires authentication"}')
+      }
+      String expectedPath = "/repos/${repoSlug}/releases/latest"
+      if (request.path?.startsWith(expectedPath)) {
+        return new MockResponse()
+            .setResponseCode(200)
+            .addHeader('Content-Type', 'application/json')
+            .setBody("""{"tag_name":"${tagName}","name":"Release ${tagName}"}""")
+      }
+      return new MockResponse().setResponseCode(404)
     }
   }
 

--- a/src/test/groovy/se/alipsa/gradle/plugin/release/ReleasePluginTest.groovy
+++ b/src/test/groovy/se/alipsa/gradle/plugin/release/ReleasePluginTest.groovy
@@ -437,6 +437,32 @@ base {
     }
   }
 
+  @Test
+  void latestGithubReleaseDetectsSshSchemeRemote() throws IOException {
+    String repoSlug = 'owner/ssh-scheme-repo'
+    String expectedTag = 'v6.0.0'
+    server.setDispatcher(new GithubReleaseDispatcher(repoSlug, expectedTag))
+
+    String githubApiBaseUrl = server.url('/').toString()
+    // ssh:// URL format (distinct from scp-style git@github.com:owner/repo.git)
+    String sshRemote = "ssh://git@localhost:${server.port}/${repoSlug}.git"
+    File testProjectDir = TestFixtures.createGithubProject(githubApiBaseUrl, repoSlug, sshRemote)
+    try {
+      BuildResult result = GradleRunner.create()
+          .withProjectDir(testProjectDir)
+          .withArguments('latestGithubRelease')
+          .withPluginClasspath()
+          .forwardOutput()
+          .build()
+
+      assertEquals(TaskOutcome.SUCCESS, result.task(':latestGithubRelease').outcome)
+      assertTrue(result.output.contains("${repoSlug}: ${expectedTag}"),
+          "Expected output to contain '${repoSlug}: ${expectedTag}' but was:\n${result.output}")
+    } finally {
+      cleanupTestProject(testProjectDir)
+    }
+  }
+
   private static final class AuthRequiredGithubReleaseDispatcher extends Dispatcher {
     private final String repoSlug
     private final String tagName

--- a/src/test/groovy/se/alipsa/gradle/plugin/release/ReleasePluginTest.groovy
+++ b/src/test/groovy/se/alipsa/gradle/plugin/release/ReleasePluginTest.groovy
@@ -276,6 +276,90 @@ base {
     }
   }
 
+  @Test
+  void latestGithubReleaseDisplaysLatestTag() throws IOException {
+    String repoSlug = 'owner/test-repo'
+    String expectedTag = 'v2.5.0'
+    server.setDispatcher(new GithubReleaseDispatcher(repoSlug, expectedTag))
+
+    String githubApiBaseUrl = server.url('/').toString()
+    File testProjectDir = TestFixtures.createGithubProject(githubApiBaseUrl, repoSlug)
+    try {
+      BuildResult firstRun = GradleRunner.create()
+          .withProjectDir(testProjectDir)
+          .withArguments('latestGithubRelease', '--configuration-cache')
+          .withPluginClasspath()
+          .forwardOutput()
+          .build()
+
+      assertEquals(TaskOutcome.SUCCESS, firstRun.task(':latestGithubRelease').outcome)
+      assertTrue(firstRun.output.contains("${repoSlug}: ${expectedTag}"),
+          "Expected output to contain '${repoSlug}: ${expectedTag}' but was:\n${firstRun.output}")
+      assertTrue(firstRun.output.contains('Configuration cache entry stored'))
+
+      BuildResult secondRun = GradleRunner.create()
+          .withProjectDir(testProjectDir)
+          .withArguments('latestGithubRelease', '--configuration-cache')
+          .withPluginClasspath()
+          .forwardOutput()
+          .build()
+
+      assertEquals(TaskOutcome.SUCCESS, secondRun.task(':latestGithubRelease').outcome)
+      assertTrue(secondRun.output.contains('Configuration cache entry reused') ||
+          secondRun.output.contains('Reusing configuration cache'))
+    } finally {
+      cleanupTestProject(testProjectDir)
+    }
+  }
+
+  @Test
+  void latestGithubReleaseReportsNoReleasesWhenNoneFound() throws IOException {
+    String repoSlug = 'owner/no-releases-repo'
+    server.setDispatcher(new GithubReleaseDispatcher(repoSlug, null))
+
+    String githubApiBaseUrl = server.url('/').toString()
+    File testProjectDir = TestFixtures.createGithubProject(githubApiBaseUrl, repoSlug)
+    try {
+      BuildResult result = GradleRunner.create()
+          .withProjectDir(testProjectDir)
+          .withArguments('latestGithubRelease')
+          .withPluginClasspath()
+          .forwardOutput()
+          .build()
+
+      assertEquals(TaskOutcome.SUCCESS, result.task(':latestGithubRelease').outcome)
+      assertTrue(result.output.contains("${repoSlug}: no releases found"),
+          "Expected output to contain '${repoSlug}: no releases found' but was:\n${result.output}")
+    } finally {
+      cleanupTestProject(testProjectDir)
+    }
+  }
+
+  private static final class GithubReleaseDispatcher extends Dispatcher {
+    private final String repoSlug
+    private final String tagName
+
+    GithubReleaseDispatcher(String repoSlug, String tagName) {
+      this.repoSlug = repoSlug
+      this.tagName = tagName
+    }
+
+    @Override
+    MockResponse dispatch(RecordedRequest request) {
+      String expectedPath = "/repos/${repoSlug}/releases/latest"
+      if (request.path?.startsWith(expectedPath)) {
+        if (tagName == null) {
+          return new MockResponse().setResponseCode(404).setBody('{"message":"Not Found"}')
+        }
+        return new MockResponse()
+            .setResponseCode(200)
+            .addHeader('Content-Type', 'application/json')
+            .setBody("""{"tag_name":"${tagName}","name":"Release ${tagName}"}""")
+      }
+      return new MockResponse().setResponseCode(404)
+    }
+  }
+
   private static final class MetadataDispatcher extends Dispatcher {
     private final Map<String, String> versionsByArtifact
 

--- a/src/test/groovy/se/alipsa/gradle/plugin/release/ReleasePluginTest.groovy
+++ b/src/test/groovy/se/alipsa/gradle/plugin/release/ReleasePluginTest.groovy
@@ -335,6 +335,55 @@ base {
     }
   }
 
+  @Test
+  void latestGithubReleaseWorksWithEnterpriseRemote() throws IOException {
+    String repoSlug = 'owner/enterprise-repo'
+    String expectedTag = 'v3.1.0'
+    server.setDispatcher(new GithubReleaseDispatcher(repoSlug, expectedTag))
+
+    String githubApiBaseUrl = server.url('/').toString()
+    String enterpriseRemote = "https://github.example.com/${repoSlug}.git"
+    File testProjectDir = TestFixtures.createGithubProject(githubApiBaseUrl, repoSlug, enterpriseRemote)
+    try {
+      BuildResult result = GradleRunner.create()
+          .withProjectDir(testProjectDir)
+          .withArguments('latestGithubRelease')
+          .withPluginClasspath()
+          .forwardOutput()
+          .build()
+
+      assertEquals(TaskOutcome.SUCCESS, result.task(':latestGithubRelease').outcome)
+      assertTrue(result.output.contains("${repoSlug}: ${expectedTag}"),
+          "Expected output to contain '${repoSlug}: ${expectedTag}' but was:\n${result.output}")
+    } finally {
+      cleanupTestProject(testProjectDir)
+    }
+  }
+
+  @Test
+  void latestGithubReleaseUsesExplicitGithubRepoWhenSet() throws IOException {
+    String repoSlug = 'owner/explicit-repo'
+    String expectedTag = 'v4.0.0'
+    server.setDispatcher(new GithubReleaseDispatcher(repoSlug, expectedTag))
+
+    String githubApiBaseUrl = server.url('/').toString()
+    File testProjectDir = TestFixtures.createGithubProjectWithExplicitRepo(githubApiBaseUrl, repoSlug)
+    try {
+      BuildResult result = GradleRunner.create()
+          .withProjectDir(testProjectDir)
+          .withArguments('latestGithubRelease')
+          .withPluginClasspath()
+          .forwardOutput()
+          .build()
+
+      assertEquals(TaskOutcome.SUCCESS, result.task(':latestGithubRelease').outcome)
+      assertTrue(result.output.contains("${repoSlug}: ${expectedTag}"),
+          "Expected output to contain '${repoSlug}: ${expectedTag}' but was:\n${result.output}")
+    } finally {
+      cleanupTestProject(testProjectDir)
+    }
+  }
+
   private static final class GithubReleaseDispatcher extends Dispatcher {
     private final String repoSlug
     private final String tagName

--- a/src/test/groovy/se/alipsa/gradle/plugin/release/TestFixtures.groovy
+++ b/src/test/groovy/se/alipsa/gradle/plugin/release/TestFixtures.groovy
@@ -286,6 +286,23 @@ class TestFixtures {
     testProjectDir
   }
 
+  static File createGithubProjectWithFakeGh(String githubApiBaseUrl, String repoSlug, String fakeToken, String remoteUrl = null) {
+    File testProjectDir = createGithubProject(githubApiBaseUrl, repoSlug, remoteUrl)
+
+    File binDir = new File(testProjectDir, 'bin')
+    binDir.mkdirs()
+    File ghScript = new File(binDir, 'gh')
+    ghScript.text = """#!/bin/sh
+if [ "\$1" = "auth" ] && [ "\$2" = "token" ]; then
+  echo "${fakeToken}"
+  exit 0
+fi
+exit 1
+"""
+    ghScript.setExecutable(true)
+    testProjectDir
+  }
+
   private static void createGroovySource(File projectDir, String fileName, String content) {
     File srcDir = new File(projectDir, 'src/main/groovy/example')
     srcDir.mkdirs()

--- a/src/test/groovy/se/alipsa/gradle/plugin/release/TestFixtures.groovy
+++ b/src/test/groovy/se/alipsa/gradle/plugin/release/TestFixtures.groovy
@@ -225,7 +225,7 @@ class TestFixtures {
     testProjectDir
   }
 
-  static File createGithubProject(String githubApiBaseUrl, String repoSlug) {
+  static File createGithubProject(String githubApiBaseUrl, String repoSlug, String remoteUrl = null) {
     File tempDir = File.createTempDir('nexus-release-plugin')
     File testProjectDir = new File(tempDir, 'github-project')
     testProjectDir.mkdirs()
@@ -248,8 +248,40 @@ class TestFixtures {
 
     createGroovySource(testProjectDir, 'Example.groovy', 'class Example {}')
 
+    String origin = remoteUrl ?: "https://github.com/${repoSlug}.git"
     ['git', 'init'].execute(null, testProjectDir).waitFor()
-    ['git', 'remote', 'add', 'origin', "https://github.com/${repoSlug}.git"].execute(null, testProjectDir).waitFor()
+    ['git', 'remote', 'add', 'origin', origin].execute(null, testProjectDir).waitFor()
+
+    testProjectDir
+  }
+
+  static File createGithubProjectWithExplicitRepo(String githubApiBaseUrl, String repoSlug) {
+    File tempDir = File.createTempDir('nexus-release-plugin')
+    File testProjectDir = new File(tempDir, 'github-explicit-project')
+    testProjectDir.mkdirs()
+
+    writeFile(new File(testProjectDir, 'settings.gradle'), "rootProject.name = 'github-explicit-project'")
+
+    writeFile(new File(testProjectDir, 'build.gradle'), """
+      plugins {
+        id 'groovy'
+        id 'se.alipsa.nexus-release-plugin'
+      }
+      group = 'com.example'
+      version = '1.0.0'
+      repositories { mavenCentral() }
+      dependencies { implementation localGroovy() }
+      nexusReleasePlugin {
+        githubApiBaseUrl = '${githubApiBaseUrl.replaceAll('/+$', '')}'
+        githubRepo = '${repoSlug}'
+      }
+    """.stripIndent())
+
+    createGroovySource(testProjectDir, 'Example.groovy', 'class Example {}')
+
+    // Non-GitHub remote — auto-detection would return null without the explicit override
+    ['git', 'init'].execute(null, testProjectDir).waitFor()
+    ['git', 'remote', 'add', 'origin', "https://gitlab.com/${repoSlug}.git"].execute(null, testProjectDir).waitFor()
 
     testProjectDir
   }

--- a/src/test/groovy/se/alipsa/gradle/plugin/release/TestFixtures.groovy
+++ b/src/test/groovy/se/alipsa/gradle/plugin/release/TestFixtures.groovy
@@ -225,6 +225,35 @@ class TestFixtures {
     testProjectDir
   }
 
+  static File createGithubProject(String githubApiBaseUrl, String repoSlug) {
+    File tempDir = File.createTempDir('nexus-release-plugin')
+    File testProjectDir = new File(tempDir, 'github-project')
+    testProjectDir.mkdirs()
+
+    writeFile(new File(testProjectDir, 'settings.gradle'), "rootProject.name = 'github-project'")
+
+    writeFile(new File(testProjectDir, 'build.gradle'), """
+      plugins {
+        id 'groovy'
+        id 'se.alipsa.nexus-release-plugin'
+      }
+      group = 'com.example'
+      version = '1.0.0'
+      repositories { mavenCentral() }
+      dependencies { implementation localGroovy() }
+      nexusReleasePlugin {
+        githubApiBaseUrl = '${githubApiBaseUrl.replaceAll('/+$', '')}'
+      }
+    """.stripIndent())
+
+    createGroovySource(testProjectDir, 'Example.groovy', 'class Example {}')
+
+    ['git', 'init'].execute(null, testProjectDir).waitFor()
+    ['git', 'remote', 'add', 'origin', "https://github.com/${repoSlug}.git"].execute(null, testProjectDir).waitFor()
+
+    testProjectDir
+  }
+
   private static void createGroovySource(File projectDir, String fileName, String content) {
     File srcDir = new File(projectDir, 'src/main/groovy/example')
     srcDir.mkdirs()


### PR DESCRIPTION
## Summary

- **New `latestGithubRelease` task**: displays the latest GitHub release tag for the repository. Auto-detected from `.git/config` (no manual config needed for public repos). Works with HTTPS and SSH remotes, git worktrees. Configuration-cache compatible — reads the git config file directly rather than spawning a `git` subprocess.
- **New extension properties**: `githubToken` (for private repos / rate limiting) and `githubApiBaseUrl` (for GitHub Enterprise, default `https://api.github.com`).
- **Improved `latestMavenVersions` messages**: the "not found" and "no release" outputs now include the `groupId:artifactId` being searched (e.g. `:app: not found in metadata repository (se.alipsa:app)`), making it much easier to diagnose when the default artifact ID (the subproject name) doesn't match the published artifact.

## Motivation

`latestMavenVersions` was unhelpful for projects that release to GitHub only — it would silently search for a Maven artifact that doesn't exist and return a confusing "not found" message with no coordinates. The new `latestGithubRelease` task is the right tool for those projects.

The improved "not found" message for `latestMavenVersions` also fixes a real confusion: when a subproject is named `app`, its default Maven `artifactId` is `app`, and the message `:app: not found in metadata repository` gave no clue what URL was being searched.

## Test plan

- [x] `latestGithubReleaseDisplaysLatestTag` — verifies tag is shown, and that the result is reused from config cache on second run
- [x] `latestGithubReleaseReportsNoReleasesWhenNoneFound` — verifies graceful 404 handling
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)